### PR TITLE
Small fixes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,9 @@ stopwords = KSP
 
 [AutoPrereqs]
 
+[Prereqs]
+IO::Socket::SSL = 0
+
 [OurPkgVersion]
 [PodWeaver]
 

--- a/perlcritic.rc
+++ b/perlcritic.rc
@@ -1,0 +1,4 @@
+[TestingAndDebugging::RequireUseStrict]
+equivalent_modules = strictures Moo Moo::Role
+[TestingAndDebugging::RequireUseWarnings]
+equivalent_modules = strictures Moo Moo::Role


### PR DESCRIPTION
Missed an optional (but required for us) dependency for HTTP::Tiny.