### PR TITLE
Better common error parsing

### DIFF
--- a/lib/App/KSP_CKAN/Tools/NetKAN.pm
+++ b/lib/App/KSP_CKAN/Tools/NetKAN.pm
@@ -86,8 +86,15 @@ method _check_lite {
 }
 
 method _parse_error($error) {
-  $error =~ m{^\[ERROR\].(.+)}m;
-  return $1;
+  my $return;
+  if ($error =~ /^\d+.\[\d+\].FATAL/) {
+    $error =~ m{FATAL.+.-.(.+)};
+    $return = $1;
+  } else {
+    $error =~ m{^\[ERROR\].(.+)}m;
+    $return = $1;
+  }
+  return $return;
 }
 
 =method inflate
@@ -109,7 +116,7 @@ method inflate {
   };
 
   if ($exit) {                                                                                                         
-    my $error = $self->_parse_error($stdout) || "' - Error wasn't parsable";                                           
+    my $error = $self->_parse_error($stdout) || "Error wasn't parsable"; 
     $self->warn("'".$self->file."' - ".$error); 
   } 
 

--- a/t/App/KSP_CKAN/Tools/NetKAN.t
+++ b/t/App/KSP_CKAN/Tools/NetKAN.t
@@ -53,7 +53,7 @@ my $netkan = App::KSP_CKAN::Tools::NetKAN->new(
 
 # TODO: Fix this on travis.
 TODO: {
-  local $TODO = "This appears to broken on travis", 4 if $ENV{TRAVIS};
+  local $TODO = "This appears to broken on travis" if $ENV{TRAVIS};
   is( $netkan->inflate, 0, "Return success correctly" );
 
   my @files = glob($test->tmp."/CKAN-meta/DogeCoinFlag");

--- a/t/App/KSP_CKAN/Tools/NetKAN.t
+++ b/t/App/KSP_CKAN/Tools/NetKAN.t
@@ -82,6 +82,12 @@ is (
   "JSON Error Parsing Success"
 );
 
+is (
+  $netkan->_parse_error("No error"),
+  undef,
+  "Return undef when no error parsed"
+);
+
 my $error = <<EOF;
 Unhandled Exception:
 CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip

--- a/t/App/KSP_CKAN/Tools/NetKAN.t
+++ b/t/App/KSP_CKAN/Tools/NetKAN.t
@@ -69,6 +69,34 @@ TODO: {
   isnt( $netkan->inflate, 0, "Return failure correctly" );
 }
 
+# Test Error Parsing
+is (
+  $netkan->_parse_error("8194 [1] FATAL CKAN.NetKAN.Program (null) - Could not find CrowdSourcedScience directory in zipfile to install"),
+  "Could not find CrowdSourcedScience directory in zipfile to install",
+  "Zipfile Error Parsing Success"
+);
+
+is (
+  $netkan->_parse_error("2142 [1] FATAL CKAN.NetKAN.Program (null) - JSON deserialization error"),
+  "JSON deserialization error",
+  "JSON Error Parsing Success"
+);
+
+my $error = <<EOF;
+Unhandled Exception:
+CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip
+  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0 
+  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0 
+[ERROR] FATAL UNHANDLED EXCEPTION: CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip
+  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0 
+  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0 
+EOF
+
+is (
+  $netkan->_parse_error( $error ),
+  "FATAL UNHANDLED EXCEPTION: CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip",
+  "Generic Error Parsing Success"
+);
 ok( -d $test->tmp."/cache", "NetKAN Cache path set correctly");
 
 # Cleanup after ourselves


### PR DESCRIPTION
See a lot of this:

```
2015/08/17 09:02:11 WARN 'NetKAN/BAM.netkan' - ' - Error wasn't parsable 
2015/08/17 09:03:03 WARN 'NetKAN/CheatMenu.netkan' - ' - Error wasn't parsable 
2015/08/17 09:03:05 WARN 'NetKAN/ChopIt.netkan' - ' - Error wasn't parsable 
2015/08/17 09:03:10 WARN 'NetKAN/CIT-Util.netkan' - ' - Error wasn't parsable 
```

This will resolve that, with tests!