### PR TITLE
Escape epochs from version strings for the mirror - closes #47

### DIFF
--- a/lib/App/KSP_CKAN/Metadata/Ckan.pm
+++ b/lib/App/KSP_CKAN/Metadata/Ckan.pm
@@ -80,6 +80,15 @@ Returns the homepage url or 0.
 
 Returns the download url or 0.
 
+=item version
+
+Returns the version field of the loaded CKAN.
+
+=item escaped_version
+
+Returns the version field of the loaded CKAN with the colons replaced
+with dashes.
+
 =back
 
 =cut
@@ -100,6 +109,7 @@ has 'homepage'              => ( is => 'ro', lazy => 1, builder => 1 );
 has 'repository'            => ( is => 'ro', lazy => 1, builder => 1 );
 has 'license'               => ( is => 'ro', lazy => 1, builder => 1 );
 has 'version'               => ( is => 'ro', lazy => 1, builder => 1 );
+has 'escaped_version'       => ( is => 'ro', lazy => 1, builder => 1 );
 
 # TODO: We're already using file slurper + JSON elsewhere. We should
 #       pick one method for consistency.
@@ -165,6 +175,13 @@ method _build_homepage {
 
 method _build_repository {
  return $self->_raw->{config}{resources}{repository};
+}
+
+method _build_escaped_version {
+  # Epochs in the version appear as a colon.
+  my $version = $self->version;
+  $version =~ s/:/-/g;
+  return $version;
 }
 
 =method licenses
@@ -260,7 +277,7 @@ Produces an item name based of the 'identifier' and 'version'.
 =cut
 
 method mirror_item {
-  return $self->identifier."-".$self->version;
+  return $self->identifier."-".$self->escaped_version;
 }
 
 =method mirror_filename
@@ -283,7 +300,7 @@ method mirror_filename {
   return 
     substr($self->download_sha1,0,8)."-"
     .$self->identifier."-"
-    .$self->version."."
+    .$self->escaped_version."."
     .$self->extension($self->download_content_type);
 }
 
@@ -297,7 +314,7 @@ Produces a mirror url based of the 'identifier' and 'version'.
 
 method mirror_url {
   # TODO: Maybe not hardcode this.
-  return "https://archive.org/details/".$self->identifier."-".$self->version;
+  return "https://archive.org/details/".$self->identifier."-".$self->escaped_version;
 }
 
 with('App::KSP_CKAN::Roles::Licenses','App::KSP_CKAN::Roles::FileServices');

--- a/t/App/KSP_CKAN/Metadata/Ckan.t
+++ b/t/App/KSP_CKAN/Metadata/Ckan.t
@@ -17,9 +17,11 @@ $test->create_ckan( file => $test->tmp."/metapackage.ckan", kind => "metapackage
 $test->create_ckan( file => $test->tmp."/nohash.ckan", kind => "nohash" );
 $test->create_ckan( file => $test->tmp."/escaped.ckan", download => 'https://example.com/url%20with%40escape%24characters%23' );
 $test->create_ckan( file => $test->tmp."/no_mirror.ckan", license => '"restricted"', download => "");
+$test->create_ckan( file => $test->tmp."/epoch.ckan", version => "3:0.15.6.5");
 $test->create_ckan( file => $test->tmp."/hash.ckan", download => "https://github.com/pjf/DogeCoinFlag/releases/download/v1.02/DogeCoinFlag-1.02.zip",  license => '[ "restricted", "GPL-2.0" ]' );
 
 my $package = App::KSP_CKAN::Metadata::Ckan->new( file => $test->tmp."/package.ckan");
+my $epoch = App::KSP_CKAN::Metadata::Ckan->new( file => $test->tmp."/epoch.ckan");
 subtest 'package' => sub {  
   is($package->identifier, 'ExampleKAN', "Package identifier successfully retrieved");
   is($package->kind, 'package', "Kind successfully retrieved");
@@ -34,6 +36,8 @@ subtest 'fields' => sub {
   is($package->name, "Example KAN", "Name successfully retrieved");
   is($package->license, "CC-BY-NC-SA", "License successfully retrieved");
   is($package->version, "1.0.0.1", "Version successfully retrieved");
+  is($epoch->escaped_version, "3-0.15.6.5", "Escaped version successfully retrieved #47");
+  is($epoch->version, "3:0.15.6.5", "Unescaped version successfully retrieved #47");
   is($package->download_sha1, '1A2B3C4D5E', "Download sha1 successfully retrieved");
   is($package->download_sha256, '1A2B3C4D5E1A2B3C4D5E', "Download sha256 successfully retrieved");
   is($package->download_content_type, 'application/zip', "Download content type successfully retrieved");
@@ -76,6 +80,11 @@ subtest 'mirror' => sub {
     "Filename '".$hash->mirror_filename."' produced correctly"
   );
   is($no_hash->mirror_filename, 0, "Content type not applicable for producing a filename");
+  is(
+    $epoch->mirror_filename, 
+    "1A2B3C4D-ExampleKAN-3-0.15.6.5.zip", 
+    "Filename with epoch '".$epoch->mirror_filename."' produced correctly #47"
+  );
 
   # Item names
   is(
@@ -83,12 +92,22 @@ subtest 'mirror' => sub {
     "ExampleKAN-1.0.0.1",
     "Item name '".$package->mirror_item."' produced correctly"
   );
+  is(
+    $epoch->mirror_item,
+    "ExampleKAN-3-0.15.6.5",
+    "Item name with epoch '".$epoch->mirror_item."' produced correctly #47"
+  );
   
   # Mirror URL
   is(
     $package->mirror_url,
     "https://archive.org/details/ExampleKAN-1.0.0.1",
     "URL '".$package->mirror_item."' produced correctly"
+  );
+  is(
+    $epoch->mirror_url,
+    "https://archive.org/details/ExampleKAN-3-0.15.6.5",
+    "URL with epoch '".$epoch->mirror_item."' produced correctly #47"
   );
 };
 

--- a/t/lib/App/KSP_CKAN/Test.pm
+++ b/t/lib/App/KSP_CKAN/Test.pm
@@ -125,6 +125,7 @@ method create_ckan(
   :$license     = '"CC-BY-NC-SA"',
   :$download    = "https://example.com/example.zip",
   :$sha256      = "1A2B3C4D5E1A2B3C4D5E",
+  :$version     = "1.0.0.1",
 ) {
   my $attribute = $valid ? "identifier" : "invalid_schema";
 
@@ -150,7 +151,7 @@ method create_ckan(
 
   # Create the CKAN
   open my $in, '>', $file;
-  print $in qq|{"spec_version": 1, "$attribute": "$identifier", "license": $license, "ksp_version": "0.90", "name": "Example KAN", "abstract": "It's a $rand example!", "author": "Techman83", "version": "1.0.0.1", $package, "resources": { "homepage": "https://example.com/homepage", "repository": "https://example.com/repository" }}|;
+  print $in qq|{"spec_version": 1, "$attribute": "$identifier", "license": $license, "ksp_version": "1.1.2", "name": "Example KAN", "abstract": "It's a $rand example!", "author": "Techman83", "version": "$version", $package, "resources": { "homepage": "https://example.com/homepage", "repository": "https://example.com/repository" }}|;
   close $in;
   return;
 }


### PR DESCRIPTION
Adds an 'escaped_version' method used by the mirror methods and tests.