### PR TITLE
Check archive for missed uploads - closes #49

### DIFF
--- a/bin/mirror-ckan
+++ b/bin/mirror-ckan
@@ -4,9 +4,13 @@ use v5.010;
 use strict;
 use autodie qw(:all);
 use App::KSP_CKAN::Tools::Config;
+use App::KSP_CKAN::Tools::Git;
 use App::KSP_CKAN::Mirror;
+use Try::Tiny;
 use Getopt::Long;
 use File::Spec;
+use File::chdir;
+use File::Path qw( mkpath );
 
 # PODNAME: mirror-ckan
 
@@ -48,24 +52,26 @@ $PROGNAME ||= 'mirror-ckan';
 my $DEBUG  = 0;
 my $filename;
 
-# TODO: It'd be nice to specify a path/multiple files 
-my $getopts_rc = GetOptions(
-  "version"       => \&version,
-  "debug!"        => \$DEBUG,
-  "ckan=s"        => \$filename,  
-
-  "help|?"        => \&print_usage,
-);
-
 # TODO: Allow config to be specified
+my $working = $ENV{HOME}."/CKAN-Webhooks/mirror";
+if ( ! -d $working ) {
+  mkpath($working);
+}
 my $config = App::KSP_CKAN::Tools::Config->new(
+  working   => $working,
   debugging => $DEBUG,
 );
 my $mirror = App::KSP_CKAN::Mirror->new( config => $config ); 
 
-$mirror->upload_ckan($filename);
+# TODO: It'd be nice to specify a path/multiple files 
+my $getopts_rc = GetOptions(
+  "version"       => \&version,
+  "debug!"        => \$DEBUG,
+  "ckan=s"        => \$filename,
+  "yesterday"     => \&yesterday,
 
-exit 0;
+  "help|?"        => \&print_usage,
+);
 
 sub version {
   $::VERSION ||= "Unreleased";
@@ -79,6 +85,8 @@ sub print_usage {
 
   mirror-ckan --ckan /path/to/file.ckan   : Takes a ckan file and mirrors it to the
                                           : Internet Archive.
+  mirror-ckan --yesterday                 : Scans CKAN-meta for files commited the day
+                                          : before and attempts to archive them.
 
   Debugging commands:
     
@@ -91,4 +99,28 @@ sub print_usage {
   exit 1;
 }
 
+sub yesterday {
+  my $git = App::KSP_CKAN::Tools::Git->new(
+    remote  => $config->CKAN_meta,
+    local   => $config->working,
+  );
+  my @files = $git->yesterdays_diff;
+  local $CWD = $config->working."/".$git->working;
+  
+  foreach my $file ( @files ) {
+    if ( $file =~ /\.ckan$/ && -e $file ) {
+      say "Checking mirror for $file" if $DEBUG;
+      try {
+        $mirror->upload_ckan($file);
+      };
+    }
+  }
+
+  exit 0;
+}
+
+# This is the default 
+$mirror->upload_ckan($filename);
+
+exit 0;
 __END__

--- a/lib/App/KSP_CKAN/Tools/Git.pm
+++ b/lib/App/KSP_CKAN/Tools/Git.pm
@@ -8,7 +8,7 @@ use Method::Signatures 20140224;
 use Carp qw(croak);
 use Try::Tiny;
 use Git::Wrapper;
-use Capture::Tiny qw(capture);
+use Capture::Tiny qw(capture capture_stdout);
 use File::chdir;
 use File::Path qw(remove_tree mkpath);
 use Moo;
@@ -246,6 +246,25 @@ method pull(:$ours?,:$theirs?) {
     $self->_git->pull;
   }
   return;
+}
+
+=method yesterdays_diff
+
+  $git->yesterdays_diff;
+
+Produces a list of files of changes since yesterday.
+
+git diff $(git rev-list -n1 --before="yesterday" master) --name-only
+
+=cut
+
+# TODO: It'd be cool to be able to test this
+method yesterdays_diff {
+  my $branch = $self->branch;
+  local $CWD = $self->local."/".$self->working;
+  my $changed = capture_stdout { system("git diff \$(git rev-list -n1 --before=\"yesterday\" $branch) --name-only") };
+  chomp $changed;
+  return split("\n", $changed);
 }
 
 1;


### PR DESCRIPTION
Tested and implemented. Captured all the mods that were missed due to Epochs yesterday.
```
2016/05/19 04:35:32 INFO AmbientLightAdjustment-2.5.7.4 Already has a file mirrrored with the SHA1 hash of C0F9E28614554106123B70C8CE1D842463C7BD6E 
2016/05/19 04:35:33 INFO AmbientLightAdjustment-2.6.7.4 Already has a file mirrrored with the SHA1 hash of C0F9E28614554106123B70C8CE1D842463C7BD6E 
2016/05/19 04:35:33 INFO Biomatic-1.1.0.6 Already has a file mirrrored with the SHA1 hash of 9BA6221015DF559BE845A17BAFF2E0888057E204 
2016/05/19 04:35:34 INFO BiomaticForAll-1.1.0.6 Already has a file mirrrored with the SHA1 hash of 9BA6221015DF559BE845A17BAFF2E0888057E204 
2016/05/19 04:35:35 INFO CryoEngines-LFO-1-0.3.2 Already has a file mirrrored with the SHA1 hash of 7C859DF2633231E491FC7BFD9D218E8D735344E5 
2016/05/19 04:35:36 INFO CryoEngines-SurfaceAttach-1-0.3.2 Already has a file mirrrored with the SHA1 hash of 7C859DF2633231E491FC7BFD9D218E8D735344E5 
2016/05/19 04:35:37 INFO CryoEngines-1-0.3.2 Already has a file mirrrored with the SHA1 hash of 7C859DF2633231E491FC7BFD9D218E8D735344E5 
2016/05/19 04:35:38 INFO CryoTanks-0.2.2 Already has a file mirrrored with the SHA1 hash of 4780DB53ED61E94AF7B783AA0E4FBFF8295E8D57 
2016/05/19 04:35:39 INFO DIRECTLaunchVehicles-1.0.0 Already has a file mirrrored with the SHA1 hash of 68E9CE4D4756AAE87C3FE0A35F6EACEBF98BA263 
2016/05/19 04:35:40 INFO DMagicOrbitalScience-1.3 Already has a file mirrrored with the SHA1 hash of 96268DA5D20B8314CB9445208E2DED40F15AAAF3 
2016/05/19 04:35:41 INFO DeployableEngines-0.2.2 Already has a file mirrrored with the SHA1 hash of 4780DB53ED61E94AF7B783AA0E4FBFF8295E8D57 
2016/05/19 04:35:42 INFO EPL-MKSLite-Patch-1.0.1 Already has a file mirrrored with the SHA1 hash of 1E1EC62FFB28BA55446AB03AB87C1BF836A0E5BE 
2016/05/19 04:35:43 INFO EVAStruts-1.0 Already has a file mirrrored with the SHA1 hash of CD0AF1A49AE18499C0B1BD0A1F02BA8E9F06DD14 
2016/05/19 04:35:44 INFO EditorExtensionsRedux-3.2.11 Already has a file mirrrored with the SHA1 hash of 9DF8969F1539C27201217651EBC279A1BD37477A 
2016/05/19 04:35:44 FATAL Ckan 'ElectricThrustEngineETE-3.0' cannot be mirrored 
2016/05/19 04:35:47 INFO Download found as /home/netkan/Cache/197DF248-netkan-FerramAerospaceResearch.zip 
2016/05/19 04:35:55 INFO FerramAerospaceResearch-3-0.15.6.5 mirrored to the Internet Archive successfully @ https://archive.org/details/FerramAerospaceResearch-3-0.15.6.5 
2016/05/19 04:35:56 INFO FinalFrontier-1.0.9-2459 Already has a file mirrrored with the SHA1 hash of 1031D6EC036695D31541BE245F2B9D4C03E49ED7 
2016/05/19 04:35:56 FATAL Ckan 'HGR-1.3.0' cannot be mirrored 
2016/05/19 04:35:57 INFO HeatShieldfortheMk1CommandPod-1.2.1 Already has a file mirrrored with the SHA1 hash of C8AB18D62FAD228E5CDA1F86550BB77AE9BD2E50 
2016/05/19 04:35:58 INFO HideEmptyTechNodes-0.4 Already has a file mirrrored with the SHA1 hash of 4C673FF49305EF3DB206B20640BB721524277664 
2016/05/19 04:35:59 INFO HotSpot-0.6.0 Already has a file mirrrored with the SHA1 hash of 7EFCF57BCA68BF470BAB52BE559E74CC6FC0E343 
2016/05/19 04:36:00 INFO KeepFit-0.10.6.4 Already has a file mirrrored with the SHA1 hash of BA72D14BD5FE5713738956D28E72A2184F64A7C0 
2016/05/19 04:36:03 INFO Download found as /home/netkan/Cache/FF88E954-netkan-CryoTanks.zip 
2016/05/19 04:36:16 INFO KerbalAtomics-1-0.2.2 mirrored to the Internet Archive successfully @ https://archive.org/details/KerbalAtomics-1-0.2.2 
2016/05/19 04:36:17 INFO KerbalFlightIndicators-R12 Already has a file mirrrored with the SHA1 hash of D47C1E5605635499AB55EC15AFADE3BFCA941233 
2016/05/19 04:36:17 FATAL Ckan 'KerbalRPNCalculator-1.1' cannot be mirrored 
2016/05/19 04:36:18 INFO KerbinSideGAP-1.4 Already has a file mirrrored with the SHA1 hash of D9A593E101AC92C3DDC89F24D83FB909A64785D9 
2016/05/19 04:36:19 INFO LEAForKSP-1.2.3 Already has a file mirrrored with the SHA1 hash of 0ACBF40FD9D20B3AFBFDBE010A9C43A4DF3641D6 
2016/05/19 04:36:20 INFO MarkOneLaboratoryExtensions-0.6.2 Already has a file mirrrored with the SHA1 hash of 4E95254C1A840DB9DB65E6C60A9563B81FEA9D46 
2016/05/19 04:36:22 INFO MarkOneLaboratoryExtensions-v0.6.1.1 Already has a file mirrrored with the SHA1 hash of 0B7CACB8DE8E91FE718F9A99012DB5750840CC5F 
2016/05/19 04:36:23 INFO NearFutureProps-0.5.0 Already has a file mirrrored with the SHA1 hash of 7EE8F2418BB22BBA9D9B0E3ECD517DC1F0540D3E 
2016/05/19 04:36:24 INFO NearFutureSpacecraft-0.5.0 Already has a file mirrrored with the SHA1 hash of 7EE8F2418BB22BBA9D9B0E3ECD517DC1F0540D3E 
2016/05/19 04:36:25 INFO Olympic1ARPIcons-v0.9.0 Already has a file mirrrored with the SHA1 hash of 9B255FDF47072E7648516980FF1A50889FA037BE 
2016/05/19 04:36:26 INFO PilotAssistant-1.12.5 Already has a file mirrrored with the SHA1 hash of 8109D392455345C2D816FCD05C3F4C80763ED3E5 
2016/05/19 04:36:27 INFO ProceduralProbes-1.1 Already has a file mirrrored with the SHA1 hash of E39C820F790212E1A4E9A2FC3F9783D84AFEACD9 
2016/05/19 04:36:27 FATAL Ckan 'RealChute-v1.4.1.1' cannot be mirrored 
2016/05/19 04:36:30 INFO Download found as /home/netkan/Cache/C464F591-netkan-SMURFF.zip 
2016/05/19 04:36:38 INFO SMURFF-1.4 mirrored to the Internet Archive successfully @ https://archive.org/details/SMURFF-1.4 
2016/05/19 04:36:39 INFO SpaceY-Lifters-1.12.7 Already has a file mirrrored with the SHA1 hash of 4C89A673EB53128308585165252A93B5412778FF 
2016/05/19 04:36:40 INFO SpaceshuttleSRB-0.5 Already has a file mirrrored with the SHA1 hash of 205CF1A70BACE21DC3AB18A8A4158A691081EE2E 
2016/05/19 04:36:41 INFO TACLS-v0.12.1 Already has a file mirrrored with the SHA1 hash of 8C5E7E53E7963486F45CAB74AF5C769D08E11E62 
2016/05/19 04:36:41 INFO Trajectories-v1.6.2 Already has a file mirrrored with the SHA1 hash of 27CF60DEDC16A6F65C886D59800C7E79B6C42CE6 
2016/05/19 04:36:42 INFO WernherChecker-v0.4.1 Already has a file mirrrored with the SHA1 hash of D111270B8D92DC8AE0065E652BCC2BD21AC0F9D2 
2016/05/19 04:36:43 INFO WildBlueTools-v1.2.3 Already has a file mirrrored with the SHA1 hash of D7CF56D187CE4AD508160AEC1BA478CAA0218713 
2016/05/19 04:36:44 INFO kOSPropMonitor-1.0 Already has a file mirrrored with the SHA1 hash of 55A05A16A0D76BF0514E51282A7230D195B23CB5 
```