### PR TITLE
Extend timeout time

### DIFF
--- a/bin/netkan-indexer
+++ b/bin/netkan-indexer
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use autodie qw(:all);
 use Sys::RunAlone;
-use Time::Limit '3000'; # Something wrong if we are taking longer than 50 mins
+use Time::Limit '5400'; # Something wrong if we are taking longer than 90 mins
 use Getopt::Long;
 use File::Spec;
 use App::KSP_CKAN::NetKAN;


### PR DESCRIPTION
@techman83

Extending the timeout time as a seperate PR from #58 so that our bot doesn't timeout again. It timed out for 2 days before the meta repo signature changed and now its timing out again, currently for 20 hours.