### PR TITLE
Capture all Netkan error text after first hyphen

### DIFF
--- a/lib/App/KSP_CKAN/Tools/NetKAN.pm
+++ b/lib/App/KSP_CKAN/Tools/NetKAN.pm
@@ -150,7 +150,7 @@ method _check_lite {
 method _parse_error($error) {
   my $return;
   if ($error =~ /^\d+.\[\d+\].FATAL/m) {
-    $error =~ m{FATAL.+.-.(.+)}m;
+    $error =~ m{FATAL.+?.-.(.+)}m;
     $return = $1;
   } else {
     $error =~ m{^\[ERROR\].(.+)}m;


### PR DESCRIPTION
## Problem

The status page currently truncates error messages.

If you try to process `CareerModePartCostNullifer` manually with netkan.exe, it says:

> 2656 [1] FATAL CKAN.NetKAN.Program (null) - C:\Users\User\AppData\Local\Temp\CdFileMgr\303747d7-0830-4d.tmp is not a valid ZIP file: Error in step EntryHeader for Budget part cost set to 0.cfg: Exception during test - 'Compression method not supported'

But the status page only says: 'Compression method not supported'

## Cause

This line extracts everything after the final hyphen in the output:

https://github.com/KSP-CKAN/NetKAN-bot/blob/81751def110ea7ecf137d2630f8e3635b35117a3/lib/App/KSP_CKAN/Tools/NetKAN.pm#L153

The first `.+` matches as many characters as it can, including hyphens if there are multiple. So the `(.+)` part only matches the text after the _last_ hyphen.

## Changes

Now the `.+` in that regex is changed to `.+?`, which makes it non-greedy, so the regex's hyphen will match the first one in the output rather than the last one. This will make the `(.+)` match the whole error.