### PR TITLE
Fix NetKAN staging

### DIFF
--- a/lib/App/KSP_CKAN/Metadata/NetKAN.pm
+++ b/lib/App/KSP_CKAN/Metadata/NetKAN.pm
@@ -100,20 +100,20 @@ method _build_license {
 }
 
 method _build_staging {
-  return $self->_raw->{config}{'x-netkan-staging'} ? $self->_raw->{config}{'x-netkan-staging'} : 0 ;
+  return $self->_raw->{config}{'x_netkan_staging'} ? $self->_raw->{config}{'x_netkan_staging'} : 0 ;
 }
 
 =method licenses
-  
+
   $ckan->licenses();
 
 Returns the license field as an array. Because unless there is
 multiple values it won't be.
 
 =cut
- 
-# Sometimes we always want an array. 
-method licenses { 
+
+# Sometimes we always want an array.
+method licenses {
   my @licenses = reftype \$self->license ne "SCALAR" ? @{$self->license} : $self->license;
   return \@licenses;
 }

--- a/t/App/KSP_CKAN/Tools/Git.t
+++ b/t/App/KSP_CKAN/Tools/Git.t
@@ -25,14 +25,14 @@ subtest 'Working Dir Parsing' => sub {
     'git@github.com:techman83/CKAN-meta.git',
     'https://github.com/techman83/CKAN-meta.git',
   );
-  
+
   foreach my $working (@test_git) {
     my $git = App::KSP_CKAN::Tools::Git->new(
       remote => $working,
       local => $test->tmp,
     );
-  
-    is($git->working, 'CKAN-meta', "'CKAN-meta' parsed from $working"); 
+
+    is($git->working, 'CKAN-meta', "'CKAN-meta' parsed from $working");
   };
 };
 
@@ -64,7 +64,7 @@ subtest 'Committing' => sub {
   is($git->changed, 1, "Commit not yet pushed");
   $git->push;
   is($git->changed, 0, "Commit pushed");
-  
+
   # Test committing all files
   for my $filename (qw(test_file2.ckan test_file3.ckan)) {
     $test->create_ckan( file => $test->tmp."/CKAN-meta/".$filename );
@@ -104,7 +104,7 @@ is(-e $test->tmp."/CKAN-meta/test_pull.ckan", 1, "Pull successful");
 # Test accidental deletes
 unlink($test->tmp."/CKAN-meta/test_file.ckan");
 $git->add;
-is($git->changed, 2, "File delete not commited");
+is($git->changed, 2, "File delete not committed");
 
 # Test cleanup
 $test->create_ckan( file => $test->tmp."/CKAN-meta/cleaned_file.ckan" );
@@ -139,7 +139,7 @@ subtest 'Git Errors' => sub {
 subtest 'Staged Commit' => sub {
   my $file = $test->tmp."/CKAN-meta/staged.ckan";
   my $identifier = "Testing";
-  
+
   # Initial File Creation
   $test->create_ckan( file => $file );
   $git->add($file);
@@ -149,21 +149,21 @@ subtest 'Staged Commit' => sub {
     identifier  => $identifier,
     message     => "New File",
   );
-  is($success, 1, "We commited a new file to staging");
+  is($success, 1, "We committed a new file to staging");
   $git->_hard_clean;
 
   is($git->current_branch, "master", "We returned to the master branch");
-  isnt(-e $file, 1, "Our staged file wasn't commited to master");
-  
+  isnt(-e $file, 1, "Our staged file wasn't committed to master");
+
   $git->checkout_branch("staging");
   is($git->current_branch, "staging", "We are on to the staging branch");
   $git->_hard_clean;
-  is(digest_file_hex( $file, "SHA-1" ), $hash, "Our staging branch was commited to");
+  is(digest_file_hex( $file, "SHA-1" ), $hash, "Our staging branch was committed to");
   $git->checkout_branch($identifier);
   is($git->current_branch, $identifier, "We are on the $identifier branch");
   $git->_hard_clean;
-  is(digest_file_hex( $file, "SHA-1" ), $hash, "Our $identifier branch was commited to");
-  
+  is(digest_file_hex( $file, "SHA-1" ), $hash, "Our $identifier branch was committed to");
+
   # File update
   $test->create_ckan( file => $file, random => 0 );
   $hash = digest_file_hex( $file, "SHA-1" );
@@ -174,13 +174,13 @@ subtest 'Staged Commit' => sub {
     message     => "Modified File",
   );
   $git->_hard_clean;
-  is($update, 1, "We commited a change to staging");
- 
-  # Get the last commit ID from staging 
+  is($update, 1, "We committed a change to staging");
+
+  # Get the last commit ID from staging
   $git->checkout_branch("staging");
   my $commit = $git->last_commit;
   $git->checkout_branch("master");
-  
+
   # Update with no changes
   $test->create_ckan( file => $file, random => 0 );
   $git->add($file);

--- a/t/data/NetKAN/NetKAN/DogeCoinFlagStaged.netkan
+++ b/t/data/NetKAN/NetKAN/DogeCoinFlagStaged.netkan
@@ -18,5 +18,5 @@
     "resources"         : {
         "homepage"      : "https://www.reddit.com/r/dogecoin/comments/1tdlgg/i_made_a_more_accurate_dogecoin_and_a_ksp_flag/"
     },
-    "x-netkan-staging"  : 1
+    "x_netkan_staging"  : 1
 }

--- a/t/lib/App/KSP_CKAN/Test.pm
+++ b/t/lib/App/KSP_CKAN/Test.pm
@@ -60,7 +60,7 @@ method _random_string {
 
   $test->create_tmp;
 
-This will deploy our temp environment. Only required if we 
+This will deploy our temp environment. Only required if we
 aren't creating a repo (one will be built on demand).
 
 =cut
@@ -80,7 +80,7 @@ Turns the named repo into a working local remote.
 
 method create_repo($repo) {
   local $CWD = $self->_tmp."/data/$repo";
-  capture { system("git", "init") }; 
+  capture { system("git", "init") };
   capture { system("git", "add", "-A") };
   capture { system("git", "commit", "-a", "-m", "Commit ALL THE THINGS!") };
   chdir("../");
@@ -90,7 +90,7 @@ method create_repo($repo) {
 }
 
 =method create_ckan
-  
+
   $test->create_ckan(file => "/path/to/file");
 
 Creates an example ckan that would pass validation at the specified
@@ -98,7 +98,7 @@ path.
 
 Takes an optional extra argument, that if set to false will create
 a ckan that won't pass schema validation.
-  
+
   $test->create_ckan( file => "/path/to/file", valid => 0);
 
 =over
@@ -114,7 +114,7 @@ validation against the schema.
 
 =item kind
 
-Allows us to specify a different kind of package. 'metadata' is the 
+Allows us to specify a different kind of package. 'metadata' is the
 only accepted one at the moment.
 
 =item license
@@ -126,10 +126,10 @@ Allows us to specify a different license.
 =cut
 
 method create_ckan(
-  :$file, 
-  :$valid       = 1, 
-  :$random      = 1, 
-  :$identifier  = "ExampleKAN", 
+  :$file,
+  :$valid       = 1,
+  :$random      = 1,
+  :$identifier  = "ExampleKAN",
   :$kind        = "package",
   :$license     = '"CC-BY-NC-SA"',
   :$download    = "https://example.com/example.zip",
@@ -157,7 +157,7 @@ method create_ckan(
 }
 
 =method cleanup
-  
+
   $test->cleanup;
 
 Does what it says on the tin, cleans up our mess.
@@ -165,17 +165,17 @@ Does what it says on the tin, cleans up our mess.
 =cut
 
 =method create_config
-  
+
   $test->create_config( optional => 0 );
 
 Creates a dummy config file for testing. The 'optional'
-defaults to true if unspecified, generating a test config 
+defaults to true if unspecified, generating a test config
 with optional values.
 
 =cut
 
 =method create_netkan
-  
+
   $test->create_netkan(file => "/path/to/file");
 
 Creates an example netkan that would pass validation at the specified
@@ -204,15 +204,15 @@ Allows us to specify a different or undef vref.
 =cut
 
 method create_netkan(
-  :$file, 
-  :$identifier  = "DogeCoinFlag", 
+  :$file,
+  :$identifier  = "DogeCoinFlag",
   :$kref        = "#/ckan/github/pjf/DogeCoinFlag",
   :$vref        = "#/ckan/ksp-avc",
   :$staging     = 0,
-  :$random      = 1, 
+  :$random      = 1,
 ) {
   my $vref_field = $vref ? qq|"\$vref" : "$vref",| : "";
-  my $staging_field = $vref ? "" : qq|,"x-netkan-staging" : 1|;
+  my $staging_field = $vref ? "" : qq|,"x_netkan_staging" : 1|;
   my $rand = $random ? $self->_random_string : "random";
 
   # Create the NetKAN
@@ -231,7 +231,7 @@ method create_config(:$optional = 1, :$nogh = 0) {
   print $in "ckan_schema=https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema\n";
   print $in "IA_access=12345678\n";
   print $in "IA_secret=87654321\n";
-  
+
   # TODO: This is a little ugly.
   if ($optional) {
     print $in "GH_token=123456789\n" if ! $nogh;
@@ -245,7 +245,7 @@ method create_config(:$optional = 1, :$nogh = 0) {
 }
 
 =method cleanup
-  
+
   $test->cleanup;
 
 Does what it says on the tin, cleans up our mess.


### PR DESCRIPTION
## Background

The NetKAN bot has a "staging" option that is intended to allow for manual review of bot updates before they go into CKAN-meta. If you put this in your .netkan:

```json
    "x_netkan_staging": true,
```

... then the bot will put your mod's updates in a separate branch and submit a pull request on GitHub, which can then have the validation scripts run and be merged by metadata maintainers if it looks OK.

The following modules currently have metadata set up to use this feature:

- ContractConfigurator-HistoricMissions
- ContractConfigurator-HistoricMissionsRSS
- FerramAerospaceResearch
- Kopernicus
- KSPInterstellarExtended
- MilitaryVehicleChassis
- PlanetWiki-OPM
- RoverFuelTanks
- RoverWheelSounds
- SovietConversion
- StockVisualEnhancements
- SVE-HighResolution
- SVE-LowResolution
- SVE-MediumResolution

## Problem

Currently the metadata does not trigger the feature. Those mods are not going through a staging procedure when they update.

## Cause

The property name is wrong in the Perl code; the hyphens should be underscores:

https://github.com/KSP-CKAN/NetKAN-bot/blob/3a659d7338443a9ebd3ffd03f603d5bcdc62892d/lib/App/KSP_CKAN/Metadata/NetKAN.pm#L102-L104

So the feature is implemented and live, but it's not being used.

## Changes

Now the correct property name is used. This will enable staging.

(Also fixed spelling of "commited" in a few message strings.)

Fixes #60.