### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ App::KSP-CKAN    [![Build Status](https://travis-ci.org/KSP-CKAN/NetKAN-bot.svg?
 Non Perl Dependencies
 =====================
 ```bash
-apt-get install liblocal-lib-perl cpanminus install build-essential mono-complete libcurl4-openssl-dev python-jsonschema  
+apt-get install liblocal-lib-perl cpanminus build-essential mono-complete libcurl4-openssl-dev python-jsonschema libdist-zilla-perl
 ```
 
 NetKAN will need certs for mono
@@ -22,6 +22,7 @@ Installation
 
 Install from git, you can then use:
 ```bash
+$ touch Changes
 $ dzil authordeps | cpanm
 $ dzil listdeps   | cpanm
 $ dzil install


### PR DESCRIPTION
## Problem

I had some problems getting this package to build, see #67's comments for details.

## Changes

The README is now updated based on my experience:

- `install` is removed from the list of Debian packages to install, since this isn't a Debian package and looks like a side effect of combining two `apt-get` commands
- `libdist-zilla-perl` is added to the list of Debian packages to install since without this you won't have a `dzil` command
- `touch Changes` is added to the steps to install, because `dzil` complains if this file doesn't exist