### PR TITLE
Option to use external GitHub API auth token

### DIFF
--- a/t/App/KSP_CKAN/NetKAN.t
+++ b/t/App/KSP_CKAN/NetKAN.t
@@ -18,7 +18,7 @@ $test->create_repo("CKAN-meta");
 $test->create_repo("NetKAN");
 
 # Config
-$test->create_config(nogh => 1);
+$test->create_config();
 my $config = App::KSP_CKAN::Tools::Config->new(
   file => $test->tmp."/.ksp-ckan",
 );

--- a/t/App/KSP_CKAN/Tools/Config.t
+++ b/t/App/KSP_CKAN/Tools/Config.t
@@ -20,7 +20,8 @@ my $config = App::KSP_CKAN::Tools::Config->new(
 
 is($config->CKAN_meta, $test->_tmp."/data/CKAN-meta", "NetKAN loaded from config");
 is($config->NetKAN, $test->_tmp."/data/NetKAN", "NetKAN loaded from config");
-is($config->GH_token, "123456789", "GH_token loaded from config");
+my $token = $ENV{GH_token} // '123456789';
+is($config->GH_token, $token, "GH_token loaded from config");
 is($config->working, $test->_tmp."/working", "working loaded from config");
 is(-d $config->working, 1, "working was automatically created");
 is($config->cache, $test->_tmp."/cache", "cache loaded from config");

--- a/t/App/KSP_CKAN/Tools/NetKAN.t
+++ b/t/App/KSP_CKAN/Tools/NetKAN.t
@@ -18,7 +18,7 @@ use App::KSP_CKAN::Status;
 my $test = App::KSP_CKAN::Test->new();
 
 # Config
-$test->create_config(nogh => 1);
+$test->create_config();
 my $config = App::KSP_CKAN::Tools::Config->new(
   file => $test->tmp."/.ksp-ckan",
 );
@@ -85,7 +85,7 @@ TODO: {
   isnt( $netkan->inflate, 0, "Return failure correctly" );
 
   subtest 'Status Setting' => sub {
-    like($status->status->{'DogeCoinFlag-broken'}{last_error}, qr/^JSON deserialization error.+/, "'last_error' set on failure");
+    like($status->status->{'DogeCoinFlag-broken'}{last_error}, qr/Required property 'version' not found/, "'last_error' set on failure");
     is($status->status->{'DogeCoinFlag-broken'}{failed}, 1, "'failed' true on failure");
     is($status->status->{'DogeCoinFlag-broken'}{last_indexed}, undef, "'last_index' undef when no successful indexing has ever occured");
     is($status->status->{'DogeCoinFlag'}{last_error}, undef, "'last_error' undef on success");

--- a/t/App/KSP_CKAN/WebHooks/InflateNetKAN.t
+++ b/t/App/KSP_CKAN/WebHooks/InflateNetKAN.t
@@ -20,7 +20,7 @@ subtest 'Scalar Identifier' => sub {
   $test->create_repo("NetKAN");
   
   # Config
-  $test->create_config(nogh => 1);
+  $test->create_config();
   my $config = App::KSP_CKAN::Tools::Config->new(
     file => $test->tmp."/.ksp-ckan",
   );
@@ -54,7 +54,7 @@ subtest 'Array of Identifiers' => sub {
   $test->create_repo("NetKAN");
   
   # Config
-  $test->create_config(nogh => 1);
+  $test->create_config();
   my $config = App::KSP_CKAN::Tools::Config->new(
     file => $test->tmp."/.ksp-ckan",
   );

--- a/t/lib/App/KSP_CKAN/Test.pm
+++ b/t/lib/App/KSP_CKAN/Test.pm
@@ -234,7 +234,10 @@ method create_config(:$optional = 1, :$nogh = 0) {
 
   # TODO: This is a little ugly.
   if ($optional) {
-    print $in "GH_token=123456789\n" if ! $nogh;
+    if (!$nogh) {
+      my $token = $ENV{GH_token} // '123456789';
+      print $in "GH_token=$token\n";
+    }
     print $in "working=".$self->_tmp."/working\n";
     print $in "cache=".$self->_tmp."/cache\n";
     print $in "IA_collection=collection\n";


### PR DESCRIPTION
## Problem

If you run `dzil install` several times per hour, the tests will eventually start failing due to throttling by the GitHub API.

## Changes

Now you can set the `GH_token` environment variable to a real auth token to override the one used by the tests. This allows them to succeed many more times per hour.

Fixes #68.