### PR TITLE
Sorting and line breaks for the download counts

### DIFF
--- a/lib/App/KSP_CKAN/DownloadCounts.pm
+++ b/lib/App/KSP_CKAN/DownloadCounts.pm
@@ -10,7 +10,7 @@ use File::chdir;
 use File::Slurper qw(read_text write_text);
 use File::Basename qw(basename);
 use Try::Tiny;
-use JSON;
+use JSON::PP;
 use File::Path qw(mkpath);
 use App::KSP_CKAN::Tools::Git;
 use Moo;
@@ -57,7 +57,12 @@ method _build__http {
 }
 
 method _build__json {
-  return JSON->new->allow_blessed(1)->convert_blessed(1);
+  return JSON::PP->new
+    ->indent(1)
+    ->indent_length(0)
+    ->canonical(1)
+    ->allow_blessed(1)
+    ->convert_blessed(1);
 }
 
 method _build__NetKAN {

--- a/lib/App/KSP_CKAN/DownloadCounts.pm
+++ b/lib/App/KSP_CKAN/DownloadCounts.pm
@@ -10,7 +10,7 @@ use File::chdir;
 use File::Slurper qw(read_text write_text);
 use File::Basename qw(basename);
 use Try::Tiny;
-use JSON::PP;
+use JSON;
 use File::Path qw(mkpath);
 use App::KSP_CKAN::Tools::Git;
 use Moo;
@@ -57,9 +57,8 @@ method _build__http {
 }
 
 method _build__json {
-  return JSON::PP->new
+  return JSON->new
     ->indent(1)
-    ->indent_length(0)
     ->canonical(1)
     ->allow_blessed(1)
     ->convert_blessed(1);


### PR DESCRIPTION
## Problem

The download counts code from #67 works!

However, the file format leaves a bit to be desired. The entire file is all one gigantic line, and the mods are listed in a randomized order which changes every time the file is generated. This means that every time the bot runs, the diff of this file will essentially amount to, "the whole thing changed again."

https://github.com/KSP-CKAN/CKAN-meta/commit/25faf8da1d05331c10edf2ee16e5935c885f9d1c

## Changes

- `indent(1)` to put line breaks between the properties
- `canonical(1)` to sort the properties by name

This will cause successive iterations of the `download_counts.json` file to have the mods listed in the same order, with each mod on its own line, which will make the diffs a bit more manageable.