### PR TITLE
Only update download counts once per day

### DIFF
--- a/lib/App/KSP_CKAN/DownloadCounts.pm
+++ b/lib/App/KSP_CKAN/DownloadCounts.pm
@@ -204,4 +204,16 @@ method write_json {
   );
 }
 
+=method last_run
+
+  $download_counts->last_run
+
+Returns the timestamp of the last commit for download_counts.json
+
+=cut
+
+method last_run {
+  return $self->ckan_meta->last_commit_time($self->_output_file) || 0;
+}
+
 1;

--- a/lib/App/KSP_CKAN/NetKAN.pm
+++ b/lib/App/KSP_CKAN/NetKAN.pm
@@ -6,6 +6,7 @@ use warnings;
 use autodie;
 use Method::Signatures 20140224;
 use File::chdir;
+use Time::Seconds;
 use Carp qw( croak );
 use App::KSP_CKAN::Status;
 use App::KSP_CKAN::DownloadCounts;
@@ -124,8 +125,11 @@ method _update_download_counts() {
     config    => $self->config,
     ckan_meta => $self->_CKAN_meta,
   );
-  $counter->get_counts;
-  $counter->write_json;
+  my $data_age = time() - $counter->last_run;
+  if ($data_age >= ONE_DAY) {
+    $counter->get_counts;
+    $counter->write_json;
+  }
 }
 
 method _push {

--- a/lib/App/KSP_CKAN/Tools/Git.pm
+++ b/lib/App/KSP_CKAN/Tools/Git.pm
@@ -449,4 +449,21 @@ method yesterdays_diff {
   return split("\n", $changed);
 }
 
+method last_commit_time($file) {
+  local $CWD = $self->local . '/' . $self->working;
+  my $output = capture_stdout { system(
+    'git', 'log',
+      # Just the most recent commit for this file
+      '-n', '1',
+      # Get output in epoch+tz format
+      "--pretty=%ad", '--date=raw',
+      '--', $file
+    )
+  };
+  if (my ($epoch) = $output =~ m{^(\d+)}) {
+    return $epoch;
+  }
+  return;
+}
+
 1;


### PR DESCRIPTION
## Problem

`CKAN-meta/download_counts.json` is updated every time the bot runs (approx. every 3-4 hours). This is much more frequently than we really need, and it clutters the repository history with a lot of extra commits.

## Changes

Now we use a `git log` command to check when the latest commit was made to the count file, and only calculate new counts if it was more than 24 hours ago. This will cut down on the number of updates that are made to this file (and slightly reduce the load on the bot server).

Note that the bot uses a "shallow" clone of CKAN-meta, meaning that the commit history is not retrieved when the bot is first run. If you start a fresh bot working directory, it will always recalculate the counts on the first run for this reason, but on subsequent runs in which that working directory is re-used, the previous bot-created history is retained and too-frequent updates will be suppressed.

(Should it be longer, like 1 week?)