### PR TITLE
Instant status updates from bot and webhooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # thanks -> http://blogs.perl.org/users/alex_balhatchet/2013/04/travis-ci-perl.html
 language: perl
 perl:
-#  - "5.22" 
+#  - "5.22"
   - "5.20"
   - "5.18"
 addons:

--- a/lib/App/KSP_CKAN/NetKAN.pm
+++ b/lib/App/KSP_CKAN/NetKAN.pm
@@ -31,7 +31,7 @@ use namespace::clean;
 =head1 DESCRIPTION
 
 Is a wrapper for the NetKAN inflater. Initially it will
-just wrap and capture errors, but the intention is to 
+just wrap and capture errors, but the intention is to
 add helper methods to check for changes in remote meta
 data and only run the inflater when required.
 
@@ -77,7 +77,7 @@ method _mirror_files {
   my $config = $self->config;
 
   # netkan.exe
-  $self->_http->mirror( 
+  $self->_http->mirror(
     url   => $config->netkan_exe,
     path  => $config->working."/netkan.exe",
     exe   => 1,
@@ -104,7 +104,10 @@ method _inflate_all(:$rescan = 1) {
   $self->_CKAN_meta->pull;
   $self->_NetKAN->pull;
   local $CWD = $self->config->working."/".$self->_NetKAN->working;
-  foreach my $file (glob("NetKAN/*.netkan")) {
+
+  my @files = glob("NetKAN/*.netkan");
+  $self->_status->prune_missing(map { ($_ =~ m{([^/.]+)\.netkan$})[0] } @files);
+  foreach my $file (@files) {
     my $netkan = App::KSP_CKAN::Tools::NetKAN->new(
       config      => $self->config,
       file        => $file,
@@ -138,7 +141,7 @@ method _push {
   return;
 }
 
-=method full_index 
+=method full_index
 
 Performs a full index of the NetKAN metadata and pushes
 it into CKAN-meta (or whichever repository is configured)
@@ -151,7 +154,6 @@ method full_index {
   $self->_update_download_counts;
   if ( ! $self->is_debug() ) {
     $self->_push;
-    $self->_status->write_json;
   }
   return;
 }
@@ -171,7 +173,6 @@ method lite_index {
   $self->_inflate_all( rescan => 0 );
   if ( ! $self->is_debug() ) {
     $self->_push;
-    $self->_status->write_json;
   }
   return;
 }

--- a/t/App/KSP_CKAN/Status.t
+++ b/t/App/KSP_CKAN/Status.t
@@ -34,7 +34,7 @@ $netkan->checked;
 my $inflated = $netkan->last_inflated;
 my $indexed = $netkan->last_indexed;
 my $checked = $netkan->last_checked;
-$status->write_json;
+$status->update_status("TestKAN", $netkan);
 
 is(-e $status->_status_file, 1, "Status file written");
 

--- a/t/App/KSP_CKAN/Tools/NetKAN.t
+++ b/t/App/KSP_CKAN/Tools/NetKAN.t
@@ -53,7 +53,7 @@ $http->mirror( url => $config->ckan_schema, path => $config->working."/CKAN.sche
 
 use_ok("App::KSP_CKAN::Tools::NetKAN");
 my $netkan = App::KSP_CKAN::Tools::NetKAN->new(
-  config    => $config, 
+  config    => $config,
   netkan    => $test->tmp."/netkan.exe",
   cache     => $test->tmp."/cache", # TODO: Test default cache location
   ckan_meta => $ckan,
@@ -64,7 +64,7 @@ my $netkan = App::KSP_CKAN::Tools::NetKAN->new(
 # TODO: Fix this on travis.
 TODO: {
    todo_skip "These tests are broken on travis", 7 if $ENV{TRAVIS};
-  
+
   my $md5 = $netkan->_output_md5;
   isnt($md5, undef, "MD5 '$md5' generated");
   is( $netkan->inflate, 0, "Return success correctly" );
@@ -73,9 +73,9 @@ TODO: {
   my @files = glob($config->working."/CKAN-meta/DogeCoinFlag/*");
   is( -e $files[0], 1, "Meta Data inflated" );
   is( $files[0], $netkan->_newest_file, "'".$netkan->_newest_file."' returned as the newest file");
-  
-  $netkan = App::KSP_CKAN::Tools::NetKAN->new( 
-    config    => $config, 
+
+  $netkan = App::KSP_CKAN::Tools::NetKAN->new(
+    config    => $config,
     netkan    => $test->tmp."/netkan.exe",
     cache     => $test->tmp."/cache",
     ckan_meta => $ckan,
@@ -83,14 +83,6 @@ TODO: {
     file      => $config->working."/NetKAN/NetKAN/DogeCoinFlag-broken.netkan"
   );
   isnt( $netkan->inflate, 0, "Return failure correctly" );
-
-  subtest 'Status Setting' => sub {
-    like($status->status->{'DogeCoinFlag-broken'}{last_error}, qr/Required property 'version' not found/, "'last_error' set on failure");
-    is($status->status->{'DogeCoinFlag-broken'}{failed}, 1, "'failed' true on failure");
-    is($status->status->{'DogeCoinFlag-broken'}{last_indexed}, undef, "'last_index' undef when no successful indexing has ever occured");
-    is($status->status->{'DogeCoinFlag'}{last_error}, undef, "'last_error' undef on success");
-    is($status->status->{'DogeCoinFlag'}{failed}, 0, "'failed' false on succes");
-  };
 
   ok( -d $test->tmp."/cache", "NetKAN Cache path set correctly");
 }
@@ -113,7 +105,7 @@ subtest 'File Validation' => sub {
 subtest 'Staged Commits' => sub {
   # Setup
   my $staged = App::KSP_CKAN::Tools::NetKAN->new(
-    config    => $config, 
+    config    => $config,
     netkan    => $test->tmp."/netkan.exe",
     cache     => $test->tmp."/cache", # TODO: Test default cache location
     ckan_meta => $ckan,
@@ -153,35 +145,35 @@ subtest 'Error Parsing' => sub {
     "Could not find CrowdSourcedScience directory in zipfile to install",
     "Zipfile Error Parsing Success"
   );
-  
+
   is (
     $netkan->_parse_error("2142 [1] FATAL CKAN.NetKAN.Program (null) - JSON deserialization error"),
     "JSON deserialization error",
     "JSON Error Parsing Success"
   );
-  
+
   my $error = <<EOF;
 Unhandled Exception:
 CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip
-  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0 
-  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0 
+  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0
+  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0
 [ERROR] FATAL UNHANDLED EXCEPTION: CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip
-  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0 
-  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0 
+  at CKAN.NetKAN.MainClass.FindRemote (Newtonsoft.Json.Linq.JObject json) [0x00000] in <filename unknown>:0
+  at CKAN.NetKAN.MainClass.Main (System.String[] args) [0x00000] in <filename unknown>:0
 EOF
-  
+
   is (
     $netkan->_parse_error( $error ),
     "FATAL UNHANDLED EXCEPTION: CKAN.Kraken: Cannot find remote and ID in kref: http://dl.dropboxusercontent.com/u/7121093/ksp-mods/KSP%5B1.0.2%5DWasdEditorCamera%5BMay20%5D.zip",
     "Generic Error Parsing Success"
   );
-  
+
   is (
     $netkan->_parse_error("791 [1] WARN CKAN.Curl (null) - Curl environment not pre-initialised, performing non-threadsafe init.\n8194 [1] FATAL CKAN.NetKAN.Program (null) - Could not find CrowdSourcedScience directory in zipfile to install"),
     "Could not find CrowdSourcedScience directory in zipfile to install",
     "Mutliline Fatal Success"
   );
-  
+
   is (
     $netkan->_parse_error( "Cookie Cat Crystal Combo powers... ACTIVATE" ),
     "Error wasn't parsable",


### PR DESCRIPTION
## Problems

- The bot runs continuously, but its status page only updates all at once at the end of a pass. It could be nice to know exactly what has updated in the last few minutes.
- Inflating a module via a web hook (pull requests or SpaceDock uploads) doesn't update the status page; instead you have to wait till the bot inflates the same module. This can be confusing for mod authors trying to solve errors from the status page.

## Causes

The status file is loaded once early on, then the changes are saved all at once at the end, only by the bot, and the API is such that if you *don't* update a particular mod, it's dropped from the status file. This makes it incompatible with the web hooks, which update only one mod and run concurrently with the bot.

## Changes

Now we lock, load, and save the status file every time we inflate a module. There is no longer a persistent reference to the status file JSON data structure, since it could be modified at any moment by the web hook. Pruning deprecated modules is now a special extra step performed only by the bot, not the web hooks. This gives us web hook status updates and instantaneous status updates from the bot.

Note that this requires us to load, parse, serialize, and save about 260 KB of JSON data per module. My system was able to do this 1000 times in a few seconds in testing, so I'm hoping this isn't a bottleneck for the bot.

Fixes #41.