### PR TITLE
Fix reading of status file

### DIFF
--- a/lib/App/KSP_CKAN/Status.pm
+++ b/lib/App/KSP_CKAN/Status.pm
@@ -85,6 +85,7 @@ method _with_status($func) {
   my $fh = IO::LockedFile->new($self->_status_file, 'a+');
 
   # Load file contents and deserialize to JSON object
+  $fh->seek(0, 0);
   my $data = $self->_json->decode(join('', <$fh>) || '{}');
 
   # Process the JSON object through function given in $func param


### PR DESCRIPTION
## Problem

Currently the status page shows only one module at a time. The rest are missing from the status file.

## Cause

As of #80 the bot writes the status file after every module. To do that, it opens a `LockedFile` instance with the `a+` file mode (because this mode supports reading, writing, and automatic creation of the file when it doesn't exist), reads it, deserializes it, changes one module's info, then serializes it and writes it out.

According to the Perl and Linux man pages:

https://perldoc.perl.org/perlfunc.html#Alphabetical-Listing-of-Perl-Functions

```
These various prefixes correspond to the fopen(3) modes of r , r+ , w , w+ , a , and a+ .
```

http://man7.org/linux/man-pages/man3/fopen.3.html

```
       a+     Open for reading and appending (writing at end of file).  The
              file is created if it does not exist.  The initial file
              position for reading is at the beginning of the file, but
              output is always appended to the end of the file.
```

Emphasis on "*The initial file position for reading is at the beginning of the file*". **This is false!** The initial file position for reading is at the **end** of the file, so if you want to read it, you need to seek to the beginning first.

This means that when we tried to read the file, Perl always told us it was empty, and all the previous data was lost.

## Fix

Now we seek to the beginning of the status file before we read it.

Fixes #81.