### PR TITLE
Populate staging reason in pull request body

### DIFF
--- a/lib/App/KSP_CKAN/Metadata/NetKAN.pm
+++ b/lib/App/KSP_CKAN/Metadata/NetKAN.pm
@@ -69,6 +69,7 @@ has 'kref'                  => ( is => 'ro', lazy => 1, builder => 1 );
 has 'vref'                  => ( is => 'ro', lazy => 1, builder => 1 );
 has 'name'                  => ( is => 'ro', lazy => 1, builder => 1 );
 has 'staging'               => ( is => 'ro', lazy => 1, builder => 1 );
+has 'staging_reason'        => ( is => 'ro', lazy => 1, builder => 1 );
 has 'license'               => ( is => 'ro', lazy => 1, builder => 1 );
 
 # TODO: We're already using file slurper + JSON elsewhere. We should
@@ -101,6 +102,10 @@ method _build_license {
 
 method _build_staging {
   return $self->_raw->{config}{'x_netkan_staging'} ? $self->_raw->{config}{'x_netkan_staging'} : 0 ;
+}
+
+method _build_staging_reason {
+  return $self->_raw->{config}{'x_netkan_staging_reason'};
 }
 
 =method licenses

--- a/lib/App/KSP_CKAN/Tools/GitHub.pm
+++ b/lib/App/KSP_CKAN/Tools/GitHub.pm
@@ -57,11 +57,11 @@ Submits a pull request using the identifier
 
 =cut
 
-method submit_pr($identifier) {
+method submit_pr($identifier, $body) {
   try {
     my $pull = $self->_github->pull_request->create_pull( {
       "title" => "NetKAN inflated: $identifier",
-      "body"  => "$identifier has been staged, please test and merge",
+      "body"  => $body || "$identifier has been staged, please test and merge",
       "head"  => "$identifier",
       "base"  => "master"
     } );

--- a/lib/App/KSP_CKAN/Tools/NetKAN.pm
+++ b/lib/App/KSP_CKAN/Tools/NetKAN.pm
@@ -197,7 +197,7 @@ method _commit($file) {
       message     => "NetKAN generated mods - $changed",
     );
     $self->info("Committed $changed to staging") if $result;
-    $self->_github->submit_pr($self->_netkan_metadata->identifier) if $self->config->GH_token && $result;
+    $self->_github->submit_pr($self->_netkan_metadata->identifier, $self->_netkan_metadata->staging_reason) if $self->config->GH_token && $result;
     return 0;
   }
 


### PR DESCRIPTION
## Motivation

See KSP-CKAN/CKAN-meta#1417 for an example of a pull request generated by the bot's staging feature.

In this case, we had a specific reason for why the mod has staging enabled: the game version is hard coded in the netkan and should be verified before indexing, to avoid releasing incorrect metadata to users. This reason is not reflected in the text of the generated pull request, so future metadata maintainers might not know to check it before merging.

## Changes

Now if you set a property `x_netkan_staging_reason` in a staged netkan, the value will be used as the body of the pull request. This will allow us to document why we enabled staging, to help future metadata maintainers in validating staged metadata.