### PR TITLE
Find netkans in subfolders

### DIFF
--- a/lib/App/KSP_CKAN/DownloadCounts.pm
+++ b/lib/App/KSP_CKAN/DownloadCounts.pm
@@ -185,7 +185,7 @@ method get_counts {
   # Chdir to NetKAN repo root
   local $CWD = $self->config->working . '/' . $self->_NetKAN->working;
   # Loop over the .netkan files
-  foreach my $file (glob('NetKAN/*.netkan')) {
+  foreach my $file (glob('NetKAN/*.netkan NetKAN/*/*.netkan')) {
     # Get this module's download count
     my $count = $self->_get_count_from_file($file);
     next unless defined($count);

--- a/lib/App/KSP_CKAN/NetKAN.pm
+++ b/lib/App/KSP_CKAN/NetKAN.pm
@@ -105,7 +105,7 @@ method _inflate_all(:$rescan = 1) {
   $self->_NetKAN->pull;
   local $CWD = $self->config->working."/".$self->_NetKAN->working;
 
-  my @files = glob("NetKAN/*.netkan");
+  my @files = glob("NetKAN/*.netkan NetKAN/*/*.netkan");
   $self->_status->prune_missing(map { ($_ =~ m{([^/.]+)\.netkan$})[0] } @files);
   foreach my $file (@files) {
     my $netkan = App::KSP_CKAN::Tools::NetKAN->new(


### PR DESCRIPTION
## Problem

KSP-CKAN/NetKAN#7222 moved `NetKAN/Kopernicus-Backport.netkan` to `NetKAN/Backports/Kopernicus.netkan` so the identifier would match the file name. However, the bot will not check files in subfolders.

## Changes

Now the `glob` calls that find netkans also look one folder deeper, as KSP-CKAN/xKAN-meta_testing#49 is doing for the pull request validation scripts. This will allow it to inflate `NetKAN/Backports/Kopernicus.netkan`.