### PR TITLE
Don't put null status objects in the status file

### DIFF
--- a/lib/App/KSP_CKAN/Status.pm
+++ b/lib/App/KSP_CKAN/Status.pm
@@ -135,7 +135,9 @@ method prune_missing(@identifiers) {
     my $new_data = {};
     # For simplicity, just copy across the ones that ARE in the input
     foreach my $id (@identifiers) {
-      $new_data->{$id} = $data->{$id};
+      if ($data->{$id}) {
+        $new_data->{$id} = $data->{$id};
+      }
     }
     return $new_data;
   });


### PR DESCRIPTION
## Problem

The bot's status file has several null values in it currently:

```sh
$ wget -O - http://status.ksp-ckan.space/status/netkan.json | python -m json.tool | egrep '^    ".*null'

    "ScottMunley": null,
    "SuperfluousNodes": null,
    "TESSSatellite": null,
    "XDHorribleWeapons": null,
```

This isn't good because it confuses the status page, see techman83/NetKAN-status#7.

## Cause

I believe this block is to blame:

https://github.com/KSP-CKAN/NetKAN-bot/blob/1fdc13f55a1ebbf25768b52e6d11c5540eb8faf6/lib/App/KSP_CKAN/Status.pm#L137-L139

This runs at the start of a bot pass, and its purpose is to remove frozen modules from the status page. It does this by creating a new status listing hash and pulling forward only those status objects that still have an active netkan file.

However, if there's an active netkan with no entry in the status file, then that code will add it to the hash with a null value. The exact sequence is:

1. New mod is indexed in a pull request (and #80 doesn't quite work as no status object is written by the web hook)
2. Bot starts a new pass
3. Bot adds a null status object for the new mod
4. Bot writes the status file the next time it processes a mod
5. Eventually the bot processes the new mod and replaces the null with a new status object with real values in it

So you can only spot this if you try to load the status page in the *first* pass after a mod is updated, *before* that mod itself is processed. And indeed I have some recollection of noticing this before, but not investigating because after a short while it would "fix itself."

### But why now? Why hasn't this been a problem earlier?

It has been a problem for a while, but only for very short periods. Two things have changed to make this more prevalent now:

- A lot of mods got added in one big group yesterday because KSP-SpaceDock/SpaceDock#188 got fixed
- The bot seems to be running slow due to issues fixed in KSP-CKAN/CKAN#2783

## Changes

Now we only copy forward non-null status objects. Newly added netkans will not be written to the status file at all until the bot processes them at least once. This will avoid writing null status objects to the file.